### PR TITLE
[2.x] Rename commands and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,54 @@ class Article extends Model
 }
 ```
 
-Set your schema definition.
+Generate an `authorizer` for your `App\Author` model.
+
+```bash
+php artisan restql:authorizer AuthorAuthorizer
+```
+
+This creates a new class in the namespace `App\Restql\Authorizers\AuthorAuthorizer`
+like the following.
+
+```php
+<?php
+
+namespace App\Restql\Authorizers;
+
+use Restql\Authorizer;
+
+final class AuthorAuthorizer extends Authorizer
+{
+    // ...
+}
+```
+
+Then add the available HTTP methods to your authorizer as follows.
+
+```php
+<?php
+
+namespace App\Restql\Authorizers;
+
+use Restql\Authorizer;
+
+final class AuthorAuthorizer extends Authorizer
+{
+    /**
+     * Can get one or more author resources.
+     *
+     * @param  array $clausules
+     * @return bool
+     */
+    public static function get(array $clausules = []): bool
+    {
+        // You could replace this with permission checks or validations.
+        return true;
+    }
+}
+```
+
+Then, set your schema definition.
 
 > Since version 2.x of this package the configuration has been updated to increase
 flexibility and internal behavior modification.
@@ -126,17 +173,7 @@ implementations.
 // config/restql.php
 
 return [
-    /*
-    |--------------------------------------------------------------------------
-    | Data resolution schema
-    |--------------------------------------------------------------------------
-    |
-    | Define a list of the models that RestQL can manipulate, create
-    | authorizers and middlewares to protect your schema definition
-    | resources.
-    |
-    | See https://github.com/gregorip02/restql/tree/stable/docs/Schema.md
-    */
+    // ...
 
     'schema' => [
         'authors' => [
@@ -144,7 +181,9 @@ return [
            'authorizer' => 'App\Restql\Authorizers\AuthorAuthorizer',
            'middlewares' => []
         ]
-    ]
+    ],
+
+    // ...
 ];
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ composer require gregorip02/restql
 Publish the package configuration.
 
 ```bash
-php artisan vendor:publish --tag=restql-config
+php artisan restql:schema
 ```
 
 Add the `RestqlAttributes` trait to your eloquent models.

--- a/config/restql.php
+++ b/config/restql.php
@@ -20,8 +20,6 @@ return [
     | Define a list of the models that RestQL can manipulate, create
     | authorizers and middlewares to protect your schema definition
     | resources.
-    |
-    | See https://github.com/gregorip02/restql/tree/stable/docs/Schema.md
     */
 
     'schema' => [],
@@ -33,8 +31,6 @@ return [
     |
     | Define custom data resolvers, you can also define permissions
     | and middlewares for clients to access it.
-    |
-    | See https://github.com/gregorip02/restql/tree/stable/docs/Resolvers.md
     */
 
     'resolvers' => [
@@ -53,8 +49,6 @@ return [
     |
     | Define a list of clauses that are available. Modify or delete the clauses
     | that do not interest you.
-    |
-    | See https://github.com/gregorip02/restql/tree/stable/docs/Clausules.md
     */
 
     'clausules' => [

--- a/docker/config/restql.php
+++ b/docker/config/restql.php
@@ -20,8 +20,6 @@ return [
     | Define a list of the models that RestQL can manipulate, create
     | authorizers and middlewares to protect your schema definition
     | resources.
-    |
-    | See https://github.com/gregorip02/restql/tree/stable/docs/Schema.md
     */
 
     'schema' => [
@@ -49,8 +47,6 @@ return [
     |
     | Define custom data resolvers, you can also define permissions
     | and middlewares for clients to access it.
-    |
-    | See https://github.com/gregorip02/restql/tree/stable/docs/Resolvers.md
     */
 
     'resolvers' => [
@@ -68,8 +64,6 @@ return [
     |
     | Define a list of clauses that are available. Modify or delete the clauses
     | that do not interest you.
-    |
-    | See https://github.com/gregorip02/restql/tree/stable/docs/Clausules.md
     */
 
     'clausules' => [

--- a/src/Console/AuthorizerMakeCommand.php
+++ b/src/Console/AuthorizerMakeCommand.php
@@ -11,7 +11,7 @@ final class AuthorizerMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $name = 'make:restql-authorizer';
+    protected $name = 'restql:authorizer';
 
     /**
      * The console command description.

--- a/src/Console/ResolverMakeCommand.php
+++ b/src/Console/ResolverMakeCommand.php
@@ -11,7 +11,7 @@ final class ResolverMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $name = 'make:restql-resolver';
+    protected $name = 'restql:resolver';
 
     /**
      * The console command description.

--- a/src/Console/SchemaRestqlCommand.php
+++ b/src/Console/SchemaRestqlCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Restql\Console;
+
+use Illuminate\Console\Command;
+
+final class SchemaRestqlCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'restql:schema';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Publish the package configuration';
+
+    /**
+     * Handle the command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->call('vendor:publish', [
+            '--tag' => 'restql-config'
+        ]);
+    }
+}

--- a/src/Providers/RestqlServiceProvider.php
+++ b/src/Providers/RestqlServiceProvider.php
@@ -5,6 +5,7 @@ namespace Restql\Providers;
 use Illuminate\Support\ServiceProvider;
 use Restql\Console\AuthorizerMakeCommand;
 use Restql\Console\ResolverMakeCommand;
+use Restql\Console\SchemaRestqlCommand;
 use Restql\Services\ConfigService;
 
 final class RestqlServiceProvider extends ServiceProvider
@@ -61,6 +62,7 @@ final class RestqlServiceProvider extends ServiceProvider
             $this->commands([
                 ResolverMakeCommand::class,
                 AuthorizerMakeCommand::class,
+                SchemaRestqlCommand::class
             ]);
         }
     }


### PR DESCRIPTION
## The following methods were renamed.

**Make a new restql authorizer**

```bash
php artisan make:restql-authorizer
```
Now is

```bash
php artisan restql:authorizer
```

**Make a new restql resolver**

```bash
php artisan make:restql-resolver
```
Now is

```bash
php artisan restql:resolver
```

## New commands

The developer can directly publish the package configuration using the following command.

```bash
php artisan restql:schema
```

This would be an alias for the following command.

```bash
php artisan vendor:publish --tag=restql-config
```