### PR TITLE
Fix load test routes in testing service provider

### DIFF
--- a/src/Providers/RestqlServiceProvider.php
+++ b/src/Providers/RestqlServiceProvider.php
@@ -25,11 +25,6 @@ final class RestqlServiceProvider extends ServiceProvider
                 return new ConfigService($app['config']['restql']);
             });
         }
-
-        if ($this->runningTests()) {
-            // Load package routes for testing.
-            $this->loadRoutesFrom(__DIR__ . '/../../tests/App/routes.php');
-        }
     }
 
     /**

--- a/tests/Provider.php
+++ b/tests/Provider.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Testing;
+
+use Illuminate\Support\ServiceProvider;
+
+final class Provider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        // Load application routes for testing.
+        $this->loadRoutesFrom(__DIR__ . '/App/routes.php');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -36,7 +36,8 @@ class TestCase extends OrchestraTestCase
     protected function getPackageProviders($app)
     {
         return [
-            'Restql\Providers\RestqlServiceProvider'
+            'Restql\Providers\RestqlServiceProvider',
+            'Testing\Provider',
         ];
     }
 

--- a/tests/Unit/RouteProviderTest.php
+++ b/tests/Unit/RouteProviderTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Testing\Unit;
+
+use Testing\TestCase;
+
+final class RouteProviderTest extends TestCase
+{
+    /**
+     * @test Accede a la ruta expuesta para testing.
+     */
+    public function testRouteForTestingIsPublished(): void
+    {
+        $response = $this->get('/restql');
+        $response->assertOk();
+    }
+}


### PR DESCRIPTION
## Hot fix

Remove the `loadRoutesFrom` method from `RestqlServiceProvider`.

This bug causes restql's own routes to be published for testing in applications that use the package.